### PR TITLE
[codex] Add regression coverage for recent fixes

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -567,6 +567,26 @@ class TestPlanCommand:
         content = Path(output_file).read_text()
         assert len(content) > 0
 
+    def test_plan_output_rejects_directory(self, runner, tmp_path):
+        import json
+        map_file = str(tmp_path / "map.json")
+        map_data = {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "total_files": 1,
+            "total_chunks": 1,
+            "languages": {"python": 1},
+            "files": [],
+        }
+        with open(map_file, "w") as f:
+            json.dump(map_data, f)
+
+        result = runner.invoke(
+            cli,
+            ["plan", "--memory-map", map_file, "--provider", "template", "-o", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+
     def test_plan_missing_memory_map_errors(self, runner, tmp_path):
         """plan should exit with an error when the memory map file does not exist."""
         result = runner.invoke(

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -144,3 +144,43 @@ class TestClear:
         in_memory_indexer.clear()
         in_memory_indexer.add_chunks([make_chunk(chunk_id="post")])
         assert in_memory_indexer.count() == 1
+
+
+class TestGetChunkStubs:
+    def test_skips_non_dict_metadata_entries(self, in_memory_indexer):
+        in_memory_indexer._collection.get = lambda include: {
+            "ids": ["good", "bad"],
+            "metadatas": [
+                {
+                    "file_path": "src/app.py",
+                    "start_line": 1,
+                    "end_line": 5,
+                    "language": "python",
+                },
+                "not-a-dict",
+            ],
+        }
+
+        stubs = in_memory_indexer.get_chunk_stubs()
+
+        assert [stub.chunk_id for stub in stubs] == ["good"]
+        assert stubs[0].file_path == "src/app.py"
+
+    def test_invalid_line_metadata_defaults_to_zeroes(self, in_memory_indexer):
+        in_memory_indexer._collection.get = lambda include: {
+            "ids": ["bad-lines"],
+            "metadatas": [
+                {
+                    "file_path": "src/app.py",
+                    "start_line": "NaN",
+                    "end_line": None,
+                    "language": "python",
+                }
+            ],
+        }
+
+        stubs = in_memory_indexer.get_chunk_stubs()
+
+        assert len(stubs) == 1
+        assert stubs[0].start_line == 0
+        assert stubs[0].end_line == 0

--- a/tests/unit/test_memory_map.py
+++ b/tests/unit/test_memory_map.py
@@ -197,6 +197,18 @@ class TestFormatMemoryMapForPrompt:
         py_pos = result.index("python")
         assert ts_pos < py_pos  # typescript (2) appears before python (1)
 
+    def test_invalid_language_counts_are_skipped(self):
+        malformed_map = {
+            "total_files": 2,
+            "total_chunks": 2,
+            "languages": {"typescript": "two", "python": 1, "go": None},
+            "files": [],
+        }
+        result = format_memory_map_for_prompt(malformed_map)
+        assert "python (1)" in result
+        assert "typescript" not in result
+        assert "go" not in result
+
     def test_malformed_chunk_missing_line_keys_does_not_crash(self):
         """format_memory_map_for_prompt should not raise for chunks missing line keys."""
         malformed_map = {


### PR DESCRIPTION
## What changed
Added focused regression tests for recent fixes in the memory map formatter, chunk-stub reconstruction, and `plan -o` path validation.

## Why
These paths changed recently and were still vulnerable to silent regressions without direct unit coverage.

## How to test
- `.\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_memory_map.py tests/unit/test_indexer.py tests/unit/test_cli.py --basetemp=.pytest_tmp --cov=playwright_god.memory_map --cov=playwright_god.indexer --cov=playwright_god.cli --cov-report=term-missing`

## Coverage evidence
Focused suite result: 67 passed.
Changed-path coverage added for:
- invalid language counts in `format_memory_map_for_prompt`
- malformed metadata handling in `RepositoryIndexer.get_chunk_stubs`
- directory rejection for `playwright-god plan -o`

## Docs updated
No README or OpenAPI changes required; behavior under test was already documented.